### PR TITLE
Ensure expected dist name is in metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl module TestLink::API
 
 0.010 2014-12-?? TEODESIAN
+    - Dist name was being set to TestLink::API instead of TestLink-API
     - Reformatted Changes as per CPAN::Changes::Spec
 
 0.009 2014-11-28 TEODESIAN

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Perl module TestLink::API
 
 0.010 2014-12-?? TEODESIAN
     - Dist name was being set to TestLink::API instead of TestLink-API
+    - Added "use 5.010" to document required version of Perl.
     - Reformatted Changes as per CPAN::Changes::Spec
 
 0.009 2014-11-28 TEODESIAN

--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Perl module TestLink::API
     - Dist name was being set to TestLink::API instead of TestLink-API
     - Added "use 5.010" to document required version of Perl.
     - Reformatted Changes as per CPAN::Changes::Spec
+    - Added github repo to pod
 
 0.009 2014-11-28 TEODESIAN
     - Add POD tests

--- a/Changes
+++ b/Changes
@@ -1,3 +1,17 @@
-0.001-0.007: More or less the attainment of Kwalitee
-0.008 - Allow platform to be passed as ID or name in reportTCResult
-0.009 - Add POD tests
+Revision history for Perl module TestLink::API
+
+0.010 2014-12-?? TEODESIAN
+    - Reformatted Changes as per CPAN::Changes::Spec
+
+0.009 2014-11-28 TEODESIAN
+    - Add POD tests
+
+0.008 2014-09-15 TEODESIAN
+    - Allow platform to be passed as ID or name in reportTCResult
+
+0.007 2014-08-17 TEODESIAN
+    - from 0.002 to this release: the attainment of Kwalitee
+
+0.001 2014-07-25 TEODESIAN
+    - First release to CPAN
+

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,7 +24,6 @@ WriteMakefile(
     },
     META_MERGE => {
         'meta-spec' => { version => 2 },
-        name        => 'TestLink::API',
         abstract    => "Provides an interface to TestLink's XMLRPC api",
         author      => ['George S. Baugh <teodesian@cpan.org>'],
         resources   => {

--- a/lib/TestLink/API.pm
+++ b/lib/TestLink/API.pm
@@ -1494,6 +1494,10 @@ __END__
 
 L<XMLRPC::Lite>
 
+=head1 REPOSITORY
+
+L<https://github.com/teodesian/TestLink-Perl>
+
 =head1 AUTHOR
 
 George Baugh <teodesian@cpan.org>

--- a/lib/TestLink/API.pm
+++ b/lib/TestLink/API.pm
@@ -1,6 +1,6 @@
 package TestLink::API;
 {
-    $TestLink::API::VERSION = '0.009';
+    $TestLink::API::VERSION = '0.010';
 }
 
 
@@ -42,6 +42,7 @@ It is by no means exhaustively implementing every TestLink API function.  Design
 =cut
 
 
+use 5.010;
 use strict;
 use warnings;
 use Carp;


### PR DESCRIPTION
Hi George,

This dist has the wrong distname in the metadata file, so I corrected that.

I made some other minor changes:
- reformatted the Changes file to follow convention
- added "use 5.010" to the module (which matches what is specified in the metadata)
- added mention of the github repo to the doc

Cheers,
Neil
